### PR TITLE
Change default X-Frame-Options

### DIFF
--- a/custom-http-headers.yaml
+++ b/custom-http-headers.yaml
@@ -5,7 +5,7 @@ custom_headers:
   Content-Security-Policy: "upgrade-insecure-requests"
   Strict-Transport-Security: "max-age=2592000"
   X-Xss-Protection: "1; mode=block"
-  X-Frame-Options: "DENY"
+  X-Frame-Options: "SAMEORIGIN"
   X-Content-Type-Options: "nosniff"
   Referrer-Policy: "strict-origin-when-cross-origin"
   Permissions-Policy: "camera=(), geolocation=()"


### PR DESCRIPTION
* Change "DENY" to "SAMEORIGIN"
X-Frame-Options' default value is "SAMEORIGIN", not "DENY".
X-Frame-Options: DENY header affects the Article Preview feature of Grav.

![image](https://github.com/trilbymedia/grav-plugin-custom-http-headers/assets/33383685/6d5aca33-7d8d-4517-9d23-288331831a7f)
