### PR TITLE
Delete X-Frame-Options header from default.

### DIFF
--- a/custom-http-headers.yaml
+++ b/custom-http-headers.yaml
@@ -5,7 +5,6 @@ custom_headers:
   Content-Security-Policy: "upgrade-insecure-requests"
   Strict-Transport-Security: "max-age=2592000"
   X-Xss-Protection: "1; mode=block"
-  X-Frame-Options: "SAMEORIGIN"
   X-Content-Type-Options: "nosniff"
   Referrer-Policy: "strict-origin-when-cross-origin"
   Permissions-Policy: "camera=(), geolocation=()"


### PR DESCRIPTION
I'm sorry for bother you.
This PR will delete X-Frame-Options and remove potential side-effect of this plugin.
#3 

> @rhukster I thought the default was SAMEORIGIN when there was no X-Frame-Options header, but I just realized it allows all iframes regardless origin.
For now, the problem of Grav itself is solved by this PR, but X-Frame-Options: SAMEORIGIN can also lead to unintended problems.
However, it seems impossible to allow all frames with the X-Frame-Options header. (Unfortunately, allow-from option deprecated)
I suggest you that delete X-Frame-Options from default example.